### PR TITLE
Stack machine

### DIFF
--- a/9cc/9cc.c
+++ b/9cc/9cc.c
@@ -281,6 +281,37 @@ Node *primary() {
   return new_node_num(expect_number());
 }
 
+void gen(Node *node) {
+  if (node->kind == ND_NUM) {
+    printf("  push %d\n", node->value);
+    return;
+  }
+
+  gen(node->left_hand_side);
+  gen(node->right_hand_side);
+
+  printf("  pop rdi\n");
+  printf("  pop rax\n");
+
+  switch (node->kind) {
+  case ND_ADD:
+    printf("  add rax, rdi\n");
+    break;
+  case ND_SUB:
+    printf("  sub rax, rdi\n");
+    break;
+  case ND_MUL:
+    printf("  imul rax, rdi\n");
+    break;
+  case ND_DIV:
+    printf("  cqo\n");
+    printf("  idiv rdi\n");
+    break;
+  }
+
+  printf("  push rax\n");
+}
+
 int main(int argc, char **argv) {
   if (argc != 2) {
     error("引数の数が正しくありません");
@@ -288,7 +319,8 @@ int main(int argc, char **argv) {
 
   // 入力をトークナイズ
   user_input = argv[1];
-  current_token = tokenize();
+  current_token = tokenize(user_input);
+  Node *node = expr();
 
   // アセンブリのヘッダ出力
   printf(".intel_syntax noprefix\n");

--- a/9cc/9cc.c
+++ b/9cc/9cc.c
@@ -308,7 +308,7 @@ void gen(Node *node) {
     printf("  idiv rdi\n");
     break;
   default:
-    break;
+    error("Unsupported node kind: %d", node->kind);
   }
 
   printf("  push rax\n");

--- a/9cc/9cc.c
+++ b/9cc/9cc.c
@@ -204,7 +204,7 @@ Token *tokenize() {
       continue;
     }
 
-    if (*input_ptr == '+' || *input_ptr == '-') {
+    if (strchr("+-*/()", *input_ptr)) {
       tail = new_token(TK_RESERVED, tail, input_ptr++);
       continue;
     }
@@ -314,7 +314,7 @@ void gen(Node *node) {
 
 int main(int argc, char **argv) {
   if (argc != 2) {
-    error("引数の数が正しくありません");
+    error("%s: invalid number of arguments", argv[0]);
   }
 
   // 入力をトークナイズ
@@ -327,20 +327,12 @@ int main(int argc, char **argv) {
   printf(".globl main\n");
   printf("main:\n");
 
-  // 最初の数値をRAXに移動
-  printf("  mov rax, %d\n", expect_number());
+  // 抽象構文木を降りながらコード生成
+  gen(node);
 
-  // 式の解析とコード生成
-  while (!at_eof()) {
-    if (consume('+')) {
-      printf("  add rax, %d\n", expect_number());
-      continue;
-    }
-
-    expect_symbol('-');
-    printf("  sub rax, %d\n", expect_number());
-  }
-
+  // stackトップに式全体の値が残っているはずなので
+  // それをRAXにロードして関数からの返り値とする
+  printf("  pop rax\n");
   printf("  ret\n");
   return 0;
 }

--- a/9cc/9cc.c
+++ b/9cc/9cc.c
@@ -307,6 +307,8 @@ void gen(Node *node) {
     printf("  cqo\n");
     printf("  idiv rdi\n");
     break;
+  default:
+    break;
   }
 
   printf("  push rax\n");
@@ -319,7 +321,7 @@ int main(int argc, char **argv) {
 
   // 入力をトークナイズ
   user_input = argv[1];
-  current_token = tokenize(user_input);
+  current_token = tokenize();
   Node *node = expr();
 
   // アセンブリのヘッダ出力

--- a/9cc/Makefile
+++ b/9cc/Makefile
@@ -6,11 +6,6 @@ CFLAGS=-std=c11 -g -static
 test: 9cc
 	./test.sh
 
-run: 9cc
-	./9cc 123 > tmp.s
-	gcc -o tmp tmp.s
-	./tmp
-
 clean:
 	rm -f 9cc *.o *~ tmp* tmp.s
 

--- a/9cc/test.sh
+++ b/9cc/test.sh
@@ -4,7 +4,7 @@ assert() {
   input="$2"
 
   ./9cc "$input" > tmp.s
-  cc -o tmp tmp.s
+  gcc -o tmp tmp.s
   ./tmp
   actual="$?"
 
@@ -19,5 +19,8 @@ assert() {
 assert 0 0
 assert 42 42
 assert 41 " 12 + 34 - 5"
+assert 47 "5+6*7"
+assert 15 "5*(9-6)"
+assert 4 "(3+5)/2"
 
 echo OK

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+compose/build:
+	docker build --platform=linux/amd64 -t 9cc . 
+
+compose/up: compose/build
+	docker run --platform=linux/amd64 -it --rm -v $(CURDIR):/home/user/work 9cc


### PR DESCRIPTION
This pull request includes significant changes to the `9cc` compiler to enhance its functionality and improve the test script. The most important changes include extending the tokenizer to handle additional operators, adding a code generation function for arithmetic operations, updating the main function to generate code from an abstract syntax tree, and enhancing the test script to use `gcc` and include more test cases.

### Enhancements to the tokenizer and parser:

* [`9cc/9cc.c`](diffhunk://#diff-2618ad080a2098731f07bb04b88d310e12e2a8529b5c49d24beae54a90a43c6dL207-R207): Extended the tokenizer to handle additional operators `*`, `/`, `(`, and `)` by using `strchr`.

### Code generation improvements:

* [`9cc/9cc.c`](diffhunk://#diff-2618ad080a2098731f07bb04b88d310e12e2a8529b5c49d24beae54a90a43c6dR284-R335): Added a new `gen` function to generate assembly code for arithmetic operations, including addition, subtraction, multiplication, and division.
* [`9cc/9cc.c`](diffhunk://#diff-2618ad080a2098731f07bb04b88d310e12e2a8529b5c49d24beae54a90a43c6dR284-R335): Updated the `main` function to generate code from an abstract syntax tree instead of directly generating code for each token.

### Test script enhancements:

* [`9cc/test.sh`](diffhunk://#diff-eba4ac1e6e407eaf4e67767d4d1cafbdd7d264442c6e5be5c4ae9b1cd9626b59L7-R7): Updated the `assert` function to use `gcc` instead of `cc` for compiling the generated assembly code.
* [`9cc/test.sh`](diffhunk://#diff-eba4ac1e6e407eaf4e67767d4d1cafbdd7d264442c6e5be5c4ae9b1cd9626b59R22-R24): Added new test cases to cover more arithmetic expressions, including multiplication, parentheses, and division.