### PR TITLE
Impl unary operator

### DIFF
--- a/9cc/9cc.c
+++ b/9cc/9cc.c
@@ -82,7 +82,7 @@ struct Node {
  * Returns:
  *   Pointer to the newly created node
  */
-Node *new_node(NodeKind kind, Node *left_hand_side, Node *right_hand_side) {
+Node *new_binary(NodeKind kind, Node *left_hand_side, Node *right_hand_side) {
   Node *node = calloc(1, sizeof(Node));
   node->kind = kind;
   node->left_hand_side = left_hand_side;
@@ -239,9 +239,9 @@ Node *expr() {
 
   for (;;) {
     if (consume('+'))
-      node = new_node(ND_ADD, node, mul());
+      node = new_binary(ND_ADD, node, mul());
     else if (consume('-'))
-      node = new_node(ND_SUB, node, mul());
+      node = new_binary(ND_SUB, node, mul());
     else
       return node;
   }
@@ -258,9 +258,9 @@ Node *mul() {
 
   for (;;) {
     if (consume('*'))
-      node = new_node(ND_MUL, node, unary());
+      node = new_binary(ND_MUL, node, unary());
     else if (consume('/'))
-      node = new_node(ND_DIV, node, unary());
+      node = new_binary(ND_DIV, node, unary());
     else
       return node;
   }
@@ -276,7 +276,7 @@ Node *unary() {
   if (consume('+'))
     return unary();
   if (consume('-'))
-    return new_node(ND_SUB, new_node_num(0), unary());
+    return new_binary(ND_SUB, new_node_num(0), unary());
   return primary();
 }
 

--- a/9cc/9cc.c
+++ b/9cc/9cc.c
@@ -82,7 +82,7 @@ struct Node {
  * Returns:
  *   Pointer to the newly created node
  */
-Node *new_binary(NodeKind kind, Node *left_hand_side, Node *right_hand_side) {
+Node *new_node(NodeKind kind, Node *left_hand_side, Node *right_hand_side) {
   Node *node = calloc(1, sizeof(Node));
   node->kind = kind;
   node->left_hand_side = left_hand_side;
@@ -239,9 +239,9 @@ Node *expr() {
 
   for (;;) {
     if (consume('+'))
-      node = new_binary(ND_ADD, node, mul());
+      node = new_node(ND_ADD, node, mul());
     else if (consume('-'))
-      node = new_binary(ND_SUB, node, mul());
+      node = new_node(ND_SUB, node, mul());
     else
       return node;
   }
@@ -258,9 +258,9 @@ Node *mul() {
 
   for (;;) {
     if (consume('*'))
-      node = new_binary(ND_MUL, node, unary());
+      node = new_node(ND_MUL, node, unary());
     else if (consume('/'))
-      node = new_binary(ND_DIV, node, unary());
+      node = new_node(ND_DIV, node, unary());
     else
       return node;
   }
@@ -276,7 +276,7 @@ Node *unary() {
   if (consume('+'))
     return unary();
   if (consume('-'))
-    return new_binary(ND_SUB, new_node_num(0), unary());
+    return new_node(ND_SUB, new_node_num(0), unary());
   return primary();
 }
 

--- a/9cc/9cc.c
+++ b/9cc/9cc.c
@@ -225,6 +225,7 @@ Token *tokenize() {
 // 関数プロトタイプ宣言
 Node *expr();
 Node *mul();
+Node *unary();
 Node *primary();
 
 /**
@@ -248,21 +249,35 @@ Node *expr() {
 
 /**
  * Parses multiplicative expressions with left-associative operators (*, /).
- * Follows the grammar rule: mul = primary ("*" primary | "/" primary)*
+ * Follows the grammar rule: mul = unary ("*" unary | "/" unary)*
  * Returns:
  *   Pointer to the root node of the parsed multiplicative expression
  */
 Node *mul() {
-  Node *node = primary();
+  Node *node = unary();
 
   for (;;) {
     if (consume('*'))
-      node = new_node(ND_MUL, node, primary());
+      node = new_node(ND_MUL, node, unary());
     else if (consume('/'))
-      node = new_node(ND_DIV, node, primary());
+      node = new_node(ND_DIV, node, unary());
     else
       return node;
   }
+}
+
+/**
+ * Parses unary expressions with optional unary operators (+, -).
+ * Follows the grammar rule: unary = ("+" | "-")? primary
+ * Returns:
+ *   Pointer to the root node of the parsed unary expression
+ */
+Node *unary() {
+  if (consume('+'))
+    return unary();
+  if (consume('-'))
+    return new_node(ND_SUB, new_node_num(0), unary());
+  return primary();
 }
 
 /**

--- a/9cc/test.sh
+++ b/9cc/test.sh
@@ -22,5 +22,8 @@ assert 41 " 12 + 34 - 5"
 assert 47 "5+6*7"
 assert 15 "5*(9-6)"
 assert 4 "(3+5)/2"
+assert 10 "-10+20"
+assert 10 "- -10"
+assert 10 "- - +10"
 
 echo OK


### PR DESCRIPTION
This pull request includes changes to the `9cc` compiler to enhance the handling of unary and binary expressions. The most important changes include renaming a function for clarity, adding a new function to handle unary expressions, and updating the test script to cover new cases.

Improvements to function naming and handling unary expressions:

* [`9cc/9cc.c`](diffhunk://#diff-2618ad080a2098731f07bb04b88d310e12e2a8529b5c49d24beae54a90a43c6dL85-R85): Renamed the `new_node` function to `new_binary` to better reflect its purpose of creating binary nodes.
* [`9cc/9cc.c`](diffhunk://#diff-2618ad080a2098731f07bb04b88d310e12e2a8529b5c49d24beae54a90a43c6dR228): Added a new function `unary` to handle unary expressions, and updated the `mul` function to use `unary` instead of `primary`. [[1]](diffhunk://#diff-2618ad080a2098731f07bb04b88d310e12e2a8529b5c49d24beae54a90a43c6dR228) [[2]](diffhunk://#diff-2618ad080a2098731f07bb04b88d310e12e2a8529b5c49d24beae54a90a43c6dL241-R282)

Updates to test cases:

* [`9cc/test.sh`](diffhunk://#diff-eba4ac1e6e407eaf4e67767d4d1cafbdd7d264442c6e5be5c4ae9b1cd9626b59R25-R27): Added new test cases to verify the correct handling of unary expressions.