### PR TITLE
Comparison operator

### DIFF
--- a/9cc/9cc.c
+++ b/9cc/9cc.c
@@ -259,13 +259,19 @@ Node *unary();
 Node *primary();
 
 /**
- * Parses expressions with left-associative operators (+, -).
+ * Parses expressions.
  * Follows the grammar rule: expr = equality
  * Returns:
  *   Pointer to the root node of the parsed expression
  */
 Node *expr() { return equality(); }
 
+/**
+ * Parses equality expressions with left-associative operators (==, !=).
+ * Follows the grammar rule: equality = relational ("==" relational | "!="
+ * relational)* Returns: Pointer to the root node of the parsed equality
+ * expression
+ */
 Node *equality() {
   Node *node = relational();
 
@@ -279,6 +285,12 @@ Node *equality() {
   }
 }
 
+/**
+ * Parses relational expressions with left-associative operators (<, <=, >, >=).
+ * Follows the grammar rule: relational = add ("<" add | "<=" add | ">" add |
+ * ">=" add)* Returns: Pointer to the root node of the parsed relational
+ * expression
+ */
 Node *relational() {
   Node *node = add();
 
@@ -296,6 +308,12 @@ Node *relational() {
   }
 }
 
+/**
+ * Parses additive expressions with left-associative operators (+, -).
+ * Follows the grammar rule: add = mul ("+" mul | "-" mul)*
+ * Returns:
+ *   Pointer to the root node of the parsed additive expression
+ */
 Node *add() {
   Node *node = mul();
 

--- a/9cc/test.sh
+++ b/9cc/test.sh
@@ -25,5 +25,23 @@ assert 4 "(3+5)/2"
 assert 10 "-10+20"
 assert 10 "- -10"
 assert 10 "- - +10"
+assert 0 '0==1'
+assert 1 '42==42'
+assert 1 '0!=1'
+assert 0 '42!=42'
+
+assert 1 '0<1'
+assert 0 '1<1'
+assert 0 '2<1'
+assert 1 '0<=1'
+assert 1 '1<=1'
+assert 0 '2<=1'
+
+assert 1 '1>0'
+assert 0 '1>1'
+assert 0 '1>2'
+assert 1 '1>=0'
+assert 1 '1>=1'
+assert 0 '1>=2'
 
 echo OK


### PR DESCRIPTION
This pull request introduces several significant changes to the `9cc` C compiler, focusing on enhancing token handling, adding support for new comparison operators, and updating the parsing and code generation logic accordingly.

### Enhancements to Token Handling:

* Added a `length` field to the `Token` structure to store the length of the token. (`9cc/9cc.c`, [9cc/9cc.cR31](diffhunk://#diff-2618ad080a2098731f07bb04b88d310e12e2a8529b5c49d24beae54a90a43c6dR31))
* Modified the `new_token` function to accept and set the token length. (`9cc/9cc.c`, [9cc/9cc.cL42-R48](diffhunk://#diff-2618ad080a2098731f07bb04b88d310e12e2a8529b5c49d24beae54a90a43c6dL42-R48))

### Support for Comparison Operators:

* Added new `NodeKind` enumerations for `==`, `!=`, `<`, and `<=` comparison operators. (`9cc/9cc.c`, [9cc/9cc.cR58-R61](diffhunk://#diff-2618ad080a2098731f07bb04b88d310e12e2a8529b5c49d24beae54a90a43c6dR58-R61))
* Implemented parsing functions for equality and relational expressions, including `equality` and `relational`. (`9cc/9cc.c`, [[1]](diffhunk://#diff-2618ad080a2098731f07bb04b88d310e12e2a8529b5c49d24beae54a90a43c6dL207-R323) [[2]](diffhunk://#diff-2618ad080a2098731f07bb04b88d310e12e2a8529b5c49d24beae54a90a43c6dL260-R342)
* Updated the `consume` and `expect_symbol` functions to handle multi-character operators. (`9cc/9cc.c`, [9cc/9cc.cL151-R177](diffhunk://#diff-2618ad080a2098731f07bb04b88d310e12e2a8529b5c49d24beae54a90a43c6dL151-R177))

### Code Generation for Comparison Operators:

* Added code generation logic for the new comparison operators (`==`, `!=`, `<`, `<=`) in the `gen` function. (`9cc/9cc.c`, [9cc/9cc.cR405-R424](diffhunk://#diff-2618ad080a2098731f07bb04b88d310e12e2a8529b5c49d24beae54a90a43c6dR405-R424))

### Tokenization Improvements:

* Added a `startswith` helper function to check for multi-character operators during tokenization. (`9cc/9cc.c`, [9cc/9cc.cR202-R205](diffhunk://#diff-2618ad080a2098731f07bb04b88d310e12e2a8529b5c49d24beae54a90a43c6dR202-R205))
* Updated the `tokenize` function to handle multi-character operators and set the correct token length for numbers. (`9cc/9cc.c`, [9cc/9cc.cL207-R323](diffhunk://#diff-2618ad080a2098731f07bb04b88d310e12e2a8529b5c49d24beae54a90a43c6dL207-R323))

### Testing:

* Added new test cases for the comparison operators in the `9cc/test.sh` script. (`9cc/test.sh`, [9cc/test.shR28-R45](diffhunk://#diff-eba4ac1e6e407eaf4e67767d4d1cafbdd7d264442c6e5be5c4ae9b1cd9626b59R28-R45))